### PR TITLE
Update helper.sh to allow successful build using build.sh

### DIFF
--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -109,8 +109,8 @@ function cdt-directory-prompt() {
 # Ensures EOSIO is installed and compatible via version listed in tests/CMakeLists.txt.
 function nodeos-version-check() {
   INSTALLED_VERSION=$(echo $($EOSIO_INSTALL_DIR/bin/nodeos --version))
-  INSTALLED_VERSION_MAJOR=$(echo $INSTALLED_VERSION | cut -f1 -d '.' | sed 's/v//g')
-  INSTALLED_VERSION_MINOR=$(echo $INSTALLED_VERSION | cut -f2 -d '.' | sed 's/v//g')
+  INSTALLED_VERSION_MAJOR=$(echo $INSTALLED_VERSION | cut -f1 -d '.' | sed 's/wax-//g')
+  INSTALLED_VERSION_MINOR=$(echo $INSTALLED_VERSION | cut -f2 -d '.')
 
   if [[ -z $INSTALLED_VERSION_MAJOR || -z $INSTALLED_VERSION_MINOR ]]; then
     echo "Could not determine EOSIO version. Exiting..."


### PR DESCRIPTION
## Change Description
Fetching and comparing version from the tags doesn't work since "v" (eosio) -> "wax-" (wax).
