### PR TITLE
WPS Improvements

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1108,6 +1108,9 @@ namespace eosiosystem {
        void rmvcompleted(name reviewer, name proposer);
 
        [[eosio::action]]
+       void cleanvotes(name reviewer, name proposer, uint64_t begin, uint64_t end);
+
+       [[eosio::action]]
        void setwpsenv(uint32_t total_voting_percent, uint32_t duration_of_voting, uint32_t max_duration_of_funding, uint32_t total_iteration_of_funding);
 
        [[eosio::action]]
@@ -1175,6 +1178,7 @@ namespace eosiosystem {
        using rmvcommittee_action = eosio::action_wrapper<"rmvcommittee"_n, &system_contract::rmvcommittee>;
        using rmvreject_action = eosio::action_wrapper<"rmvreject"_n, &system_contract::rmvreject>;
        using rmvcompleted_action = eosio::action_wrapper<"rmvcompleted"_n, &system_contract::rmvcompleted>;
+       using cleanvotes_action = eosio::action_wrapper<"cleanvotes"_n, &system_contract::cleanvotes>;
        using setwpsenv_action = eosio::action_wrapper<"setwpsenv"_n, &system_contract::setwpsenv>;
        using setwpsstate_action = eosio::action_wrapper<"setwpsstate"_n, &system_contract::setwpsstate>;
        using rejectfund_action = eosio::action_wrapper<"rejectfund"_n, &system_contract::rejectfund>;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1081,9 +1081,6 @@ namespace eosiosystem {
        );
 
        [[eosio::action]]
-       void rmvproposal(name proposer);
-
-       [[eosio::action]]
        void regreviewer(name committee, name reviewer, const string& first_name, const string& last_name);
 
        [[eosio::action]]
@@ -1165,7 +1162,6 @@ namespace eosiosystem {
        using rmvproposer_action = eosio::action_wrapper<"rmvproposer"_n, &system_contract::rmvproposer>;
        using regproposal_action = eosio::action_wrapper<"regproposal"_n, &system_contract::regproposal>;
        using editproposal_action = eosio::action_wrapper<"editproposal"_n, &system_contract::editproposal>;
-       using rmvproposal_action = eosio::action_wrapper<"rmvproposal"_n, &system_contract::rmvproposal>;
        using claimfunds_action = eosio::action_wrapper<"claimfunds"_n, &system_contract::claimfunds>;
        using regreviewer_action = eosio::action_wrapper<"regreviewer"_n, &system_contract::regreviewer>;
        using editreviewer_action = eosio::action_wrapper<"editreviewer"_n, &system_contract::editreviewer>;

--- a/contracts/eosio.system/src/wps.cpp
+++ b/contracts/eosio.system/src/wps.cpp
@@ -345,17 +345,6 @@ namespace eosiosystem {
         });
     }
 
-    void system_contract::rmvproposal(name proposer){
-        // needs authority of the proposers's account
-        require_auth(proposer);
-
-        // verify that the account already exists in the proposer table
-        auto itr = _proposals.find(proposer.value);
-        check(itr != _proposals.end(), "Account not found in proposal table");
-
-        _proposals.erase(itr);
-    }
-
     void system_contract::regreviewer(name committee, name reviewer, const string& first_name, const string& last_name){
         //Require permission of committee account
         require_auth(committee);

--- a/contracts/eosio.system/src/wps.cpp
+++ b/contracts/eosio.system/src/wps.cpp
@@ -544,7 +544,7 @@ namespace eosiosystem {
 
         check(end > begin, "Invalid range");
 
-        for (auto wpsvoter = _wpsvoters.begin() + begin; wpsvoter != _wpsvoters.begin() + end; wpsvoter++){
+        for (auto wpsvoter = std::advance(_wpsvoters.begin(), begin); wpsvoter != std::advance(_wpsvoters.begin(), end); wpsvoter++){
             std::vector<name> votes = wpsvoter->proposals;
             auto it = votes.begin();
             if(votes.begin() != votes.end()){

--- a/contracts/eosio.system/src/wps.cpp
+++ b/contracts/eosio.system/src/wps.cpp
@@ -544,7 +544,7 @@ namespace eosiosystem {
 
         check(end > begin, "Invalid range");
 
-        for (auto wpsvoter = std::advance(_wpsvoters.begin(), begin); wpsvoter != std::advance(_wpsvoters.begin(), end); wpsvoter++){
+        for (auto wpsvoter = std::next(_wpsvoters.begin(), begin); wpsvoter != std::next(_wpsvoters.begin(), end); wpsvoter++){
             std::vector<name> votes = wpsvoter->proposals;
             auto it = votes.begin();
             if(votes.begin() != votes.end()){

--- a/tests/eosio.wps_tests.cpp
+++ b/tests/eosio.wps_tests.cpp
@@ -613,7 +613,8 @@ core_sym::from_string("10.0000"), core_sym::from_string("10.0000"));
     // bigvoter1111 votes for prod11111111
     BOOST_REQUIRE_EQUAL( success(), vote( N(bigvoter1111), { N(prod11111111) } ) );
 
-    produce_blocks(1);
+    produce_block(fc::days(10));
+    BOOST_REQUIRE_EQUAL( success(), push_action(N(prod11111111), N(claimrewards), mvo()("owner", "prod11111111")) );
 
     BOOST_REQUIRE_EQUAL(error("missing authority of smallvoter11"), voteproposal(N(proposer1111), N(smallvoter11), {N(proposer1111)}));
 
@@ -723,7 +724,8 @@ BOOST_FIXTURE_TEST_CASE(proposal_reject_fund, eosio_wps_tester) try {
     // bigvoter1111 votes for prod11111111
     BOOST_REQUIRE_EQUAL( success(), vote( N(bigvoter1111), { N(prod11111111) } ) );
 
-    produce_blocks(1);
+    produce_block(fc::days(10));
+    BOOST_REQUIRE_EQUAL( success(), push_action(N(prod11111111), N(claimrewards), mvo()("owner", "prod11111111")) );
 
     BOOST_REQUIRE_EQUAL(success(), voteproposal(N(bigvoter1111), N(bigvoter1111), {N(proposer1111)}));
 

--- a/tests/eosio.wps_tests.cpp
+++ b/tests/eosio.wps_tests.cpp
@@ -212,16 +212,6 @@ public:
         );
     }
 
-    action_result rmvproposal(name sender,
-                              name proposer) {
-        return push_action(
-                sender,
-                N(rmvproposal),
-                mvo()
-                        ("proposer", proposer)
-        );
-    }
-
     action_result setwpsenv(name sender, uint32_t total_voting_percent, uint32_t duration_of_voting,
                             uint32_t max_duration_of_funding, uint32_t total_iteration_of_funding) {
         return push_action(
@@ -501,10 +491,6 @@ proposal = get_proposal(N(proposer1111));
 
 BOOST_REQUIRE_EQUAL(proposal["title"], "First proposal");
 
-BOOST_REQUIRE_EQUAL(wasm_assert_msg("Account not found in proposal table"), rmvproposal(N(randomuser11), N(randomuser11)));
-
-BOOST_REQUIRE_EQUAL(success(), rmvproposal(N(proposer1111), N(proposer1111)));
-
 } FC_LOG_AND_RETHROW()
 
 
@@ -516,6 +502,8 @@ create_account_with_resources(N(reviewer1111), config::system_account_name, core
 core_sym::from_string("10.0000"), core_sym::from_string("10.0000"));
 create_account_with_resources(N(proposer1111), config::system_account_name, core_sym::from_string("100.0000"), false,
 core_sym::from_string("10.0000"), core_sym::from_string("10.0000"));
+create_account_with_resources(N(proposer2222), config::system_account_name, core_sym::from_string("100.0000"), false,
+core_sym::from_string("10.0000"), core_sym::from_string("10.0000"));
 create_account_with_resources(N(randomuser11), config::system_account_name, core_sym::from_string("100.0000"), false,
 core_sym::from_string("10.0000"), core_sym::from_string("10.0000"));
 
@@ -523,8 +511,11 @@ setwpsenv(config::system_account_name, 5, 30, 500, 6);
 regcommittee(config::system_account_name, N(committee111), "categoryX", true);
 regreviewer(N(committee111), N(committee111), N(reviewer1111), "bob", "bob");
 regproposer(N(proposer1111), N(proposer1111), "user", "one", "img_url", "bio", "country", "telegram", "website", "linkedin");
+regproposer(N(proposer1111), N(proposer2222), "user", "two", "img_url", "bio", "country", "telegram", "website", "linkedin");
 regproposal(N(proposer1111), N(proposer1111), N(committee111), 1, "title", "summary", "project_img_url",
 "description", "roadmap", 30, {"user"}, core_sym::from_string("9000.0000"), 3);
+regproposal(N(proposer2222), N(proposer2222), N(committee111), 1, "title", "summary", "project_img_url",
+"description", "roadmap", 30, {"user 2"}, core_sym::from_string("9000.0000"), 3);
 
 BOOST_REQUIRE_EQUAL(error("missing authority of reviewer1111"),
         acceptprop(N(proposer1111), N(reviewer1111), N(proposer1111)));
@@ -547,20 +538,13 @@ auto proposal = get_proposal(N(proposer1111));
 
 BOOST_REQUIRE_EQUAL(proposal["status"], 2);
 
-BOOST_REQUIRE_EQUAL(success(), rmvproposal(N(proposer1111), N(proposer1111)));
+produce_blocks(1);
+
+BOOST_REQUIRE_EQUAL(success(), acceptprop(N(reviewer1111), N(reviewer1111), N(proposer2222)));
 
 produce_blocks(1);
 
-regproposal(N(proposer1111), N(proposer1111), N(committee111), 1, "title", "summary", "project_img_url",
-"description", "roadmap", 30, {"user"}, core_sym::from_string("9000.0000"), 3);
-
-produce_blocks(1);
-
-BOOST_REQUIRE_EQUAL(success(), acceptprop(N(reviewer1111), N(reviewer1111), N(proposer1111)));
-
-produce_blocks(1);
-
-proposal = get_proposal(N(proposer1111));
+proposal = get_proposal(N(proposer2222));
 
 BOOST_REQUIRE_EQUAL(proposal["status"], 3);
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. -->
- Send tokens from `eosio.saving` instead of `eosio`
- Remove votes on proposer once proposal is deleted (implemented new cleanup function called `cleanvotes`)
- Allow voters to vote for up to 30 proposals
- Get rid of the `rmvproposal` action